### PR TITLE
Automated trunk upgrade golangci-lint2 2.4.0 → 2.5.0 [skip ci]

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -21,7 +21,7 @@ lint:
     - actionlint@1.7.7
     - git-diff-check
     - gofmt@1.25.1 # datasource=golang-version depName=go
-    - golangci-lint2@2.4.0
+    - golangci-lint2@2.5.0
     - markdownlint@0.45.0
     - yamlfmt@0.17.2
     - yamllint@1.37.1


### PR DESCRIPTION

1 linter was upgraded:

- golangci-lint2 2.4.0 → 2.5.0

