### PR TITLE
Automated trunk upgrade actionlint 1.7.7 → 1.7.12, golangci-lint2 2.5.0 → 2.11.4, markdownlint 0.45.0 → 0.48.0, yamlfmt 0.17.2 → 0.21.0, yamllint 1.37.1 → 1.38.0, trunk-io/plugins v1.7.2 → v1.8.0, python 3.11.9 → 3.14.4 [skip ci]

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -18,7 +18,6 @@ runtimes:
 # This is the section where you manage your linters. (https://docs.trunk.io/check/configuration)
 lint:
   enabled:
-    - grype@0.111.1
     - actionlint@1.7.12
     - git-diff-check
     - gofmt@1.25.1 # datasource=golang-version depName=go
@@ -29,6 +28,7 @@ lint:
   disabled:
     - checkov
     - gokart
+    - grype
     - osv-scanner
     - prettier
     - renovate

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -7,24 +7,25 @@ cli:
 plugins:
   sources:
     - id: trunk
-      ref: v1.7.2
+      ref: v1.8.0
       uri: https://github.com/trunk-io/plugins
 # Many linters and tools depend on runtimes - configure them here. (https://docs.trunk.io/runtimes)
 runtimes:
   enabled:
     - go@1.25.1! # datasource=golang-version depName=go
     - node@22.16.0
-    - python@3.11.9
+    - python@3.14.4
 # This is the section where you manage your linters. (https://docs.trunk.io/check/configuration)
 lint:
   enabled:
-    - actionlint@1.7.7
+    - grype@0.111.1
+    - actionlint@1.7.12
     - git-diff-check
     - gofmt@1.25.1 # datasource=golang-version depName=go
-    - golangci-lint2@2.5.0
-    - markdownlint@0.45.0
-    - yamlfmt@0.17.2
-    - yamllint@1.37.1
+    - golangci-lint2@2.11.4
+    - markdownlint@0.48.0
+    - yamlfmt@0.21.0
+    - yamllint@1.38.0
   disabled:
     - checkov
     - gokart


### PR DESCRIPTION

6 linters were upgraded:

- actionlint 1.7.7 → 1.7.12
- golangci-lint2 2.5.0 → 2.11.4
- grype new → 0.111.1
- markdownlint 0.45.0 → 0.48.0
- yamlfmt 0.17.2 → 0.21.0
- yamllint 1.37.1 → 1.38.0

1 plugin was upgraded:

- trunk-io/plugins v1.7.2 → v1.8.0

1 runtime was upgraded:

- python 3.11.9 → 3.14.4

