### PR TITLE
Automated trunk upgrade golangci-lint2 2.11.4 → 2.12.2, trunk-io/plugins v1.8.0 → v1.9.0 [skip ci]

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -7,7 +7,7 @@ cli:
 plugins:
   sources:
     - id: trunk
-      ref: v1.8.0
+      ref: v1.9.0
       uri: https://github.com/trunk-io/plugins
 # Many linters and tools depend on runtimes - configure them here. (https://docs.trunk.io/runtimes)
 runtimes:
@@ -21,7 +21,7 @@ lint:
     - actionlint@1.7.12
     - git-diff-check
     - gofmt@1.26.3 # datasource=golang-version depName=go
-    - golangci-lint2@2.11.4
+    - golangci-lint2@2.12.2
     - markdownlint@0.48.0
     - yamlfmt@0.21.0
     - yamllint@1.38.0


### PR DESCRIPTION

1 linter was upgraded:

- golangci-lint2 2.11.4 → 2.12.2

1 plugin was upgraded:

- trunk-io/plugins v1.8.0 → v1.9.0

