### PR TITLE
Automated trunk upgrade trunk-io/plugins v1.9.0 → v1.10.2 [skip ci]

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -7,7 +7,7 @@ cli:
 plugins:
   sources:
     - id: trunk
-      ref: v1.9.0
+      ref: v1.10.2
       uri: https://github.com/trunk-io/plugins
 # Many linters and tools depend on runtimes - configure them here. (https://docs.trunk.io/runtimes)
 runtimes:


### PR DESCRIPTION

1 plugin was upgraded:

- trunk-io/plugins v1.9.0 → v1.10.2

